### PR TITLE
Modified the Reservations status styling

### DIFF
--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,1 @@
+[1228/005900.513:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/src/pages/Reservations/components/CustomTable.jsx
+++ b/src/pages/Reservations/components/CustomTable.jsx
@@ -38,7 +38,9 @@ const CustomTable = (props: Props): React.Node => {
             <TableRow>
               <TableCell>{item.date}</TableCell>
               <TableCell align="center">{item.place}</TableCell>
-              <TableCell align="right">{item.status}</TableCell>
+              <TableCell align="right" className={styles[item.status]}>
+                {item.status}
+              </TableCell>
               {props.isHistory ? null : (
                 <TableCell align="right">
                   <IconButton>

--- a/src/pages/Reservations/index.jsx
+++ b/src/pages/Reservations/index.jsx
@@ -21,18 +21,18 @@ const Reservations = () => {
 
   const activeRes = [
     createRes('pending'),
+    createRes('approved'),
     createRes('pending'),
+    createRes('rejected'),
     createRes('pending'),
-    createRes('pending'),
-    createRes('pending'),
-    createRes('pending'),
+    createRes('approved'),
   ];
 
   const history = [
     createRes('rejected'),
+    createRes('approved'),
     createRes('rejected'),
-    createRes('rejected'),
-    createRes('rejected'),
+    createRes('approved'),
     createRes('rejected'),
   ];
 

--- a/src/pages/Reservations/style.js
+++ b/src/pages/Reservations/style.js
@@ -16,6 +16,15 @@ const useStylesLocal = makeStyles({
   cancel: {
     color: '#f50057',
   },
+  pending: {
+    color: '#f9a825',
+  },
+  approved: {
+    color: '#2e7d32',
+  },
+  rejected: {
+    color: '#b71c1c',
+  },
 });
 
 export default useStylesLocal;


### PR DESCRIPTION
## Description
Styled coloring of reservations status - pending, approved, rejected.

## Screenshots
![image](https://user-images.githubusercontent.com/37110358/103180908-08918600-48b4-11eb-8d31-60b036779819.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change which optimizes existing code)
- [ ] Refactoring (non-breaking change which refactors code)
- [x] Styling (non-breaking change which restyles design)
- [ ] Other
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
